### PR TITLE
Temporary work-around for redmine 4.x

### DIFF
--- a/db/migrate/001_add_landing_page_to_projects.rb
+++ b/db/migrate/001_add_landing_page_to_projects.rb
@@ -1,4 +1,4 @@
-class AddLandingPageToProjects < ActiveRecord::Migration
+class AddLandingPageToProjects < ActiveRecord::Migration[5.2]
   def change
     add_column :projects, :landing_page, :string
   end

--- a/db/migrate/002_add_landing_page_to_users.rb
+++ b/db/migrate/002_add_landing_page_to_users.rb
@@ -1,4 +1,4 @@
-class AddLandingPageToUsers < ActiveRecord::Migration
+class AddLandingPageToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :landing_page, :string
   end


### PR DESCRIPTION
 paperclip is deprecated and Rails 6 does not allow inheriting
 from ActiveRecord::Migration. Added a version (5.2 seems reasonable)